### PR TITLE
Simplify including modelling info

### DIFF
--- a/atest/robotMBT tests/parse_model_info/MyProcessor.py
+++ b/atest/robotMBT tests/parse_model_info/MyProcessor.py
@@ -1,0 +1,13 @@
+from robot.api.deco import library, not_keyword
+
+@library
+class MyProcessor:
+    @not_keyword
+    def process_test_suite(self, in_suite):
+        msg = "Model info not properly parsed"
+        for scenario in in_suite.scenarios:
+            assert scenario.steps, msg
+            for step in scenario.steps:
+                assert step.model_info['IN'] == ['Alfa'], f"{msg} in step {step.keyword}"
+                assert step.model_info['OUT'] == ['Beta', 'Gamma delta', 'Epsilon'], f"{msg} in step {step.keyword}"
+        return in_suite

--- a/atest/robotMBT tests/parse_model_info/model_info.robot
+++ b/atest/robotMBT tests/parse_model_info/model_info.robot
@@ -16,6 +16,9 @@ leading model info
 sandwitched model info
     sandwitched model info
 
+model info on multiple lines
+    model info on multiple lines
+
 model info with altenative spacing
     model info with altenative spacing
 
@@ -51,6 +54,15 @@ sandwitched model info
     ...    :OUT: Beta | Gamma delta | Epsilon
     ...
     ...    text after model info
+    Log    Hello world!
+
+model info on multiple lines
+    [Documentation]    Text
+    ...    *model info*
+    ...    :IN: Alfa
+    ...    :OUT: Beta
+    ...    Gamma delta |
+    ...    | Epsilon |
     Log    Hello world!
 
 model info with altenative spacing

--- a/atest/robotMBT tests/parse_model_info/model_info.robot
+++ b/atest/robotMBT tests/parse_model_info/model_info.robot
@@ -1,0 +1,66 @@
+*** Settings ***
+Suite Setup       Treat this test suite Model-based
+Library           MyProcessor.py
+Library           robotmbt    processor_lib=MyProcessor
+
+*** Test cases ***
+consise model info
+    consise model info
+
+trailing model info
+    trailing model info
+
+leading model info
+    leading model info
+
+sandwitched model info
+    sandwitched model info
+
+model info with altenative spacing
+    model info with altenative spacing
+
+*** Keywords ***
+consise model info
+    [Documentation]    *model info*
+    ...    :IN: Alfa
+    ...    :OUT: Beta | Gamma delta | Epsilon
+    Log    Hello world!
+
+trailing model info
+    [Documentation]    Text
+    ...    before model info
+    ...    *model info*
+    ...    :IN: Alfa
+    ...    :OUT: Beta | Gamma delta | Epsilon
+    Log    Hello world!
+
+leading model info
+    [Documentation]    *model info*
+    ...    :IN: Alfa
+    ...    :OUT: Beta | Gamma delta | Epsilon
+    ...
+    ...    text after model info
+    Log    Hello world!
+
+sandwitched model info
+    [Documentation]    Text
+    ...    before model info
+    ...
+    ...    *model info*
+    ...    :IN: Alfa
+    ...    :OUT: Beta | Gamma delta | Epsilon
+    ...
+    ...    text after model info
+    Log    Hello world!
+
+model info with altenative spacing
+    [Documentation]    Text
+    ...    before model info
+    ...
+    ...    *model info*
+    ...    :IN : Alfa
+    ...    : OUT: Beta |Gamma delta|
+    ...    |Epsilon |
+    ...
+    ...    text after model info
+    Log    Hello world!

--- a/atest/robotMBT tests/scenario_linking/03__double_dependency.robot
+++ b/atest/robotMBT tests/scenario_linking/03__double_dependency.robot
@@ -6,7 +6,7 @@ Documentation     There are three test cases, one must go first. The other two a
 ...               force the model to reorganise the scenarios.
 Suite Setup       Suite setup
 Suite Teardown    Should be equal    ${test_count}    ${3}
-Test Setup        Set Global Variable    ${test_count}    ${test_count+1}
+Test Setup        Test setup
 Resource          birthday_cards.resource
 Library           robotmbt
 
@@ -16,22 +16,35 @@ trailing scenario
     when 'Tannaz' writes their name on the birthday card
     then the birthday card has 'Johan' written on it
     and the birthday card has 'Tannaz' written on it
-    [Teardown]    Should be equal    ${test_count}    ${3}
+    [Teardown]    Check order    ${3}
 
 middle scenario
     Given the birthday card has 1 name written on it
     when 'Nicolas' writes their name on the birthday card
     then the birthday card has 'Nicolas' written on it
     and the birthday card has 2 names written on it
-    [Teardown]    Should be equal    ${test_count}    ${2}
+    [Teardown]    Check order    ${2}
 
 leading scenario
     Given a blank birthday card
     when 'Johan' writes their name on the birthday card
     then the birthday card has 'Johan' written on it
-    [Teardown]    Should be equal    ${test_count}    ${1}
+    [Teardown]    Check order    ${1}
 
 *** Keywords ***
 Suite setup
     Set Global Variable    ${test_count}    ${0}
     Treat this test suite Model-based
+
+Test setup
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: None
+    Set Global Variable    ${test_count}    ${test_count+1}
+
+Check order
+    [Arguments]    ${order}
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: None
+    Should be equal    ${test_count}    ${order}

--- a/atest/robotMBT tests/scenario_linking/birthday_cards.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards.resource
@@ -1,31 +1,27 @@
 *** Keywords ***
 a blank Birthday card
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: new birthday_card | birthday_card.names=[]
     Log    choosing a birthday card with baloons
     @{names}=    Create list
     Set suite variable    ${names}
 
-model a blank Birthday card
-    Set Model preconditions     None
-    Set Model postconditions    new birthday_card    birthday_card.names \= []
-
 '${name}' writes their name on the birthday card
+    [Documentation]    *model info*
+    ...    :IN: birthday_card
+    ...    :OUT: birthday_card.names.append('${name}')
     Log    Writing '${name}' on the birthday card
     Set suite variable    @{names}    @{names}    ${name}
 
-model '${name}' writes their name on the birthday card
-    Set Model preconditions     birthday_card
-    Set Model postconditions    birthday_card.names.append('${name}')
-
 the birthday card has '${name}' written on it
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: None
     Should Contain    ${names}    ${name}
 
-model the birthday card has '${name}' written on it
-    Set Model preconditions     None
-    Set model postconditions    None
-
 the birthday card has ${n} name${plural} written on it
+    [Documentation]    *model info*
+    ...    :IN: len(birthday_card.names) == ${n}
+    ...    :OUT: None
     Length should be    ${names}    ${{int(${n})}}
-
-model the birthday card has ${n} name${plural} written on it
-    Set Model preconditions     len(birthday_card.names) == ${n}
-    Set model postconditions    None

--- a/demo/Titanic/Titanic_the_ship.resource
+++ b/demo/Titanic/Titanic_the_ship.resource
@@ -3,6 +3,9 @@ Library           DateTime
 
 *** Keywords ***
 The ship is docked in the harbour, preparing for the departure
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: new ship | ship.name =Titanic | ship.state=preparing_for_departure | ship.people_on_board=0 | ship.lifeboat_seats=1178
     Set Suite Variable    ${current_ship}    Titanic
     Log    Engines are off
     Log    Ropes are tied
@@ -10,110 +13,94 @@ The ship is docked in the harbour, preparing for the departure
     Log    Cargo cranes are deployed
     Log    Captain on the bridge
 
-Model the ship is docked in the harbour, preparing for the departure
-    Set Model preconditions    None
-    Set Model postconditions    new ship    ship.name\=Titanic    ship.state\=preparing_for_departure    ship.people_on_board\=0    ship.lifeboat_seats\=1178
-
 the ship is ready for departure
+    [Documentation]    *model info*
+    ...    :IN: ship.state==preparing_for_departure or ship.state==ready_for_departure
+    ...    :OUT: ship.state=ready_for_departure
     Log    waiting for further instructions
 
-Model the ship is ready for departure
-    Set Model preconditions    ship.state\=\=preparing_for_departure or ship.state\=\=ready_for_departure
-    Set Model postconditions    ship.state\=ready_for_departure
-
 The ship is fueled up
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: None
     Log    Cleaning out the old ash
     Log    Loading 8000 ton coal in ${current_ship}'s bunker
     Log    Refitting filters for water pumps
 
-Model the ship is fueled up
-    Set Model preconditions    None
-    Set Model postconditions    None
-
 the supplies are stocked
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: None
     Log    Loading beverages
     Log    Loading snacks
     Log    Loading something healthy
 
-Model the supplies are stocked
-    Set Model preconditions    None
-    Set Model postconditions    None
-
 the cargo is loaded
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: None
     Log    Loading mail for Royal mail
     Log    Loading painting La Circassienne au Bain for Mauritz Håkan Björnström-Steffansson
 
-Model the cargo is loaded
-    Set Model preconditions    None
-    Set Model postconditions    None
-
 the passengers are on board
+    [Documentation]    *model info*
+    ...    :IN: ship.people_on_board
+    ...    :OUT: ship.people_on_board+=1316
     Log    Embarking third class
     Log    Embarking second class
     Log    Waiting for first class passengers
     Log    Embarking first class
 
-Model the passengers are on board
-    Set Model preconditions    ship.people_on_board
-    Set Model postconditions    ship.people_on_board+\=1316
-
 the crew is on board
+    [Documentation]    *model info*
+    ...    :IN: ship.people_on_board
+    ...    :OUT: ship.people_on_board+=908
     Log    Captain Edward John Smith
     Log    Chief mate Henry Tingle Wilde
     Log    Lookout Fredrick Fleet
     Log    Lookout Reginald Lee
     Log    And 904 others
 
-Model the crew is on board
-    Set Model preconditions    ship.people_on_board
-    Set Model postconditions    ship.people_on_board+\=908
-
 the planned departure time is passed
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: None
     Log    Well, we are just over 100 years late, so I guess the time has passed
 
-Model the planned departure time is passed
-    Set Model preconditions    None
-    Set Model postconditions    None
-
 the ship departs
+    [Documentation]    *model info*
+    ...    :IN: ship.state==ready_for_departure or ship.state==departing
+    ...    :OUT: ship.state=departing
     Log    Starting the engines
     Log    Untying the ropes
     Log    Navigating through the harbour
 
-Model the ship departs
-    Set Model preconditions    ship.state\=\=ready_for_departure or ship.state\=\=departing
-    Set Model postconditions    ship.state\=departing
-
 the ship leaves the harbour
+    [Documentation]    *model info*
+    ...    :IN: ship.state==departing
+    ...    :OUT: ship.state=journey
     Log    Arriving in open water
 
-model the ship leaves the harbour
-    Set Model preconditions    ship.state\=\=departing
-    Set Model postconditions    ship.state\=journey
-
 the ship is on its journey
+    [Documentation]    *model info*
+    ...    :IN: ship.state==journey
+    ...    :OUT: None
     Log    Sailing the sea
 
-model the ship is on its journey
-    Set Model preconditions    ship.state\=\=journey
-    Set Model postconditions    None
-
 the current time is the departure time for the itenerary's section
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: None
     ${now}=    Get current date
     Log    Captain's log: Official registered time of departure ${now}
 
-model the current time is the departure time for the itenerary's section
-    Set Model preconditions    None
-    Set Model postconditions    None
-
 there are ${n} people on board
+    [Documentation]    *model info*
+    ...    :IN: ship.people_on_board==${n}
+    ...    :OUT: None
     Log    Counting crew: 908
     Log    Counting passengers: 1316
     Log    Not counting the rats
-
-model there are ${n} people on board
-    Set Model preconditions    ship.people_on_board\=\=${n}
-    Set Model postconditions    None
 
 Available lifeboats
     Log    14 standard wooden lifeboats x65 seats: capacity 910 people
@@ -123,9 +110,8 @@ Available lifeboats
     [Return]    ${1178}
 
 there are at least ${n} seats available in the lifeboats
+    [Documentation]    *model info*
+    ...    :IN: ship.lifeboat_seats
+    ...    :OUT: None
     ${lifeboat_seats}=    Available lifeboats
     Should Be True    ${lifeboat_seats} >= ${n}
-
-model there are at least ${n} seats available in the lifeboats
-    Set Model preconditions    ship.lifeboat_seats
-    Set Model postconditions    None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robotframework-mbt"
-version = "0.1.0"
+version = "0.2.0"
 description = "Model-Based Testing in Robot framework with test case generation"
 readme = "README.md"
 authors = [{ name = "Johan Foederer", email = "github@famfoe.nl" }]
@@ -19,7 +19,7 @@ classifiers = [
 ]
 keywords = ["robotframework", "robot", "mbt", "bdd", "testing"]
 dependencies = [
-    "robotframework >= 5.1",
+    "robotframework >= 6.0",
 ]
 requires-python = ">=3.8"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 keywords = ["robotframework", "robot", "mbt", "bdd", "testing"]
 dependencies = [
-    "robotframework",
+    "robotframework >= 5.1",
 ]
 requires-python = ">=3.8"
 

--- a/robotmbt/suitedata.py
+++ b/robotmbt/suitedata.py
@@ -54,10 +54,14 @@ class Step:
         self.parent = parent     # Parent scenario for easy searching and processing
         self.gherkin_kw = None   # given, when, then or None for non-bdd keywords
         self.args = ()           # Comes directly from Robot
-        self.model_info = dict(IN=[], OUT=[]) # Can optionally contain an additional error field
-                                 # IN and OUT are lists of Pyhton evaluatable expressions. The
-                                 # vocab.attribute form can be used to express relations between
-                                 # properties from the domain vocabulaire.
+        self.model_info = dict() # Modelling information is available as a dictionary.
+                                 # The standard format is dict(IN=[], OUT=[]) and can
+                                 # optionally contain an error field.
+                                 # IN and OUT are lists of Python evaluatable expressions.
+                                 # The `new vocab` form can be used to create new domain objects.
+                                 # The `vocab.attribute` form can then be used to express relations
+                                 # between properties from the domain vocabulaire.
+                                 # Custom processors can define their own attributes.
 
     @property
     def step_kw(self):

--- a/robotmbt/suiteprocessors.py
+++ b/robotmbt/suiteprocessors.py
@@ -120,6 +120,9 @@ class SuiteProcessors:
     def _scenario_can_execute(scenario, model):
         m = copy.deepcopy(model)
         for step in scenario.steps:
+            if 'error' in step.model_info:
+                logger.debug(f"Error in scenario {scenario.name} at step {step.keyword}: {step.model_info['error']}")
+                return False
             for expr in step.model_info['IN'] + step.model_info['OUT']:
                 try:
                     if m.process_expression(expr) is False:

--- a/robotmbt/suitereplacer.py
+++ b/robotmbt/suitereplacer.py
@@ -52,7 +52,7 @@ class SuiteReplacer:
         self.robot_suite = None
         self.current_step = None
         suite_processor = SuiteProcessors() if processor_lib is None \
-                                          else Robot.get_library_instance(processor_lib)
+                                            else Robot.get_library_instance(processor_lib)
         self.suite_processor = getattr(suite_processor, processor)
 
     @keyword(name="Treat this test suite Model-based")
@@ -157,7 +157,7 @@ class SuiteReplacer:
 
     def __fill_in_args(self, step, expressions):
         kw_def = Robot._namespace.get_runner(step.bare_kw)._handler.name
-        emb_args = EmbeddedArguments(kw_def)
+        emb_args = EmbeddedArguments.from_name(kw_def)
         re_pattern = emb_args.name
         arg_values = dict()
         if re_pattern:

--- a/robotmbt/suitereplacer.py
+++ b/robotmbt/suitereplacer.py
@@ -155,7 +155,7 @@ class SuiteReplacer:
                 raise ValueError(format_msg)
             key = elms[1].strip()
             values = [e.strip() for e in elms[-1].split("|") if e]
-            if lines and not lines[0].startswith(":"):
+            while lines and not lines[0].startswith(":"):
                 values.extend([e.strip() for e in lines.pop(0).split("|") if e])
             values = self.__fill_in_args(step, values)
             model_info[key] = values

--- a/robotmbt/suitereplacer.py
+++ b/robotmbt/suitereplacer.py
@@ -79,15 +79,11 @@ class SuiteReplacer:
             logger.debug(f"    with setup: {in_suite.setup.name}")
             self.prev_gherkin_kw = None
             step_info = self.__process_step(in_suite.setup, parent=out_suite)
-            if step_info.gherkin_kw != 'given':
-                step_info.model_info['error'] = "Setup must be a 'given' step"
             out_suite.setup = step_info
         if in_suite.teardown and parent is not None:
             logger.debug(f"    with teardown: {in_suite.teardown.name}")
             self.prev_gherkin_kw = None
             step_info = self.__process_step(in_suite.teardown, parent=out_suite)
-            if step_info.gherkin_kw != 'then':
-                step_info.model_info['error'] = "Teardown must be a 'then' step"
             out_suite.teardown = step_info
         for st in in_suite.suites:
             out_suite.suites.append(self.__process_robot_suite(st, parent=out_suite))
@@ -99,15 +95,11 @@ class SuiteReplacer:
                 logger.debug(f"    with setup: {tc.setup.name}")
                 self.prev_gherkin_kw = None
                 step_info = self.__process_step(tc.setup, parent=scenario)
-                if step_info.gherkin_kw != 'given':
-                    step_info.model_info['error'] = "Setup must be a 'given' step"
                 scenario.setup = step_info
             if tc.teardown:
                 logger.debug(f"    with teardown: {tc.teardown.name}")
                 self.prev_gherkin_kw = None
                 step_info = self.__process_step(tc.teardown, parent=scenario)
-                if step_info.gherkin_kw != 'then':
-                    step_info.model_info['error'] = "Teardown must be a 'then' step"
                 scenario.teardown = step_info
             logger.debug('    ' + '\n    '.join([st.name + " " + " ".join([str(s) for s in st.args]) for st in tc.body]))
             self.prev_gherkin_kw = None

--- a/robotmbt/version.py
+++ b/robotmbt/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0'
+VERSION = '0.2.0'


### PR DESCRIPTION
By moving the modelling info from separate keywords into the docstring we get these benefits:
* More concise modelling info
* Modeling info directly linked to keywords
* No need to escape equal signs (\=)
* No additional keywords in namespace
* No name clashes when keywords start or end with an argument