### PR TITLE
Some scenario improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With this project we aim to get the best of both worlds. Allowing testers to wri
 
 The recommended installation method is using [pip](http://pip-installer.org)
 
-    pip install robotframework-mbt
+    pip install --upgrade robotframework-mbt
 
 After installation include `robotmbt` as library in your robot file to get access to the new functionality.
 
@@ -49,6 +49,11 @@ you have a blank postcard
     [Documentation]    *model info*
     ...    :IN: postcard.wish==None
     ...    :OUT: postcard.wish==None
+
+you write '${your_wish}' on the postcard
+    [Documentation]    *model info*
+    ...    :IN: postcard.wish==None
+    ...    :OUT: postcard.wish=${your_wish}
 ```
 
 The first scenario can be executed directly. It has no dependencies that need to be resolved before going into its first step, as indicated by the `:IN:` expression which is `None`. After completing the step, a new domain term is available with a single property. The term `postcard` with property `wish` is introduced, as stated by the `:OUT:` expressions. This satisfies the condition for the then-step to complete this scenario.
@@ -59,7 +64,7 @@ The second scenario has a dependency to the first scenario, due to the condition
 * when-steps evaluate both the `:IN:` and `:OUT:` expressions
 * then-steps evaluate only the `:OUT:` expressions
 
-If evaluation of any expressions fails or is False, then the scenario is rejected. By properly annotating all steps to reflect their impact on the system or its environment, you can model the intended relations between scenarios. This forms the specification model. The step implementations use keywords to connect to the system under test to verify the specified behaviour.
+If evaluation of any expression fails or is False, then the scenario is rejected. By properly annotating all steps to reflect their impact on the system or its environment, you can model the intended relations between scenarios. This forms the specification model. You can keep your models clean by deleting terms (e.g. `del postcard`) that are no longer relevant. The step implementations use keywords to connect to the system under test to verify the specified behaviour.
 
 There are three typical kinds of steps
 

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
@@ -62,6 +62,7 @@ there is text added in ${style} on the birthday card
     ...    :IN: artwork.name
     ...    :OUT: artwork.name+=${name}[1:] | birthday_card.names.append(artwork.name)
     ...          birthday_card.style = calligraphy
+    ...          del artwork
     ${other_letters}=    Get substring    ${name}    1
     Log    ${name} writes ${other_letters} in a matching font
     Set suite variable    @{names}    @{names}    ${name}
@@ -73,6 +74,7 @@ there is text added in ${style} on the birthday card
     ...    :IN: birthday_card | new _pencil
     ...    :OUT: _pencil.tip==sharp | birthday_card.names.append(${name})
     ...          birthday_card.style = pencil
+    ...          del _pencil
     Set suite variable    @{names}    @{names}    ${name}
     Log    ${name} prefers to use a pencil for writing
     Set suite variable    ${writing style}    pencil

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
@@ -5,7 +5,7 @@ Library    String
 buying a birthday card
     [Documentation]    *model info*
     ...    :IN: None
-    ...    :OUT: new birthday_card | birthday_card.names=[]
+    ...    :OUT: new birthday_card
     Log    choosing a birthday card with baloons
     @{names}=    Create list
     Set suite variable    ${names}
@@ -13,7 +13,7 @@ buying a birthday card
 there is a blank Birthday card
     [Documentation]    *model info*
     ...    :IN: birthday_card.names==[]
-    ...    :OUT: birthday_card.names==[]
+    ...    :OUT: birthday_card.names=[]
     Log    The card has balloons on the front, but the inside looks a bit empy
 
 there is a birthday card

--- a/demo/Titanic/Titanic_the_ship.resource
+++ b/demo/Titanic/Titanic_the_ship.resource
@@ -123,7 +123,7 @@ No passengers have boarded yet
 Boarding first class passengers
     [Documentation]    *model info*
     ...    :IN: ship.people_on_board
-    ...    :OUT: ship.people_on_board+=116 | ship.people_on_board==2224
+    ...    :OUT: ship.people_on_board+=325
     Log    Waiting for first class passengers, because they are always late
     Log    Embarking first class
     
@@ -131,12 +131,12 @@ Boarding first class passengers
 Boarding second class passengers
     [Documentation]    *model info*
     ...    :IN: ship.people_on_board
-    ...    :OUT: ship.people_on_board+=700
+    ...    :OUT: ship.people_on_board+=285
     Log    Embarking second class
 
 Boarding third class passengers
     [Documentation]    *model info*
     ...    :IN: ship.people_on_board==908
-    ...    :OUT: ship.people_on_board+=500
+    ...    :OUT: ship.people_on_board+=706
     Log    Third class embarks first
     Log    Embarking third class

--- a/robotmbt/modelspace.py
+++ b/robotmbt/modelspace.py
@@ -46,6 +46,12 @@ class ModelSpace:
         self.props[name] = ModelSpace()
         setattr(self, name, self.props[name])
 
+    def del_prop(self, name):
+        if name not in self.props:
+            raise ModellingError(f"Delete failed, '{name}' is not defined.")
+        self.props.pop(name)
+        delattr(self, name)
+
     def __dir__(self, recurse=True):
         if recurse:
             return [attr for attr in self.__dir__(False) if attr not in self.std_attrs]
@@ -54,8 +60,12 @@ class ModelSpace:
 
     def process_expression(self, expr):
         expr = expr.strip()
-        if self.is_new_vocab_expression(expr):
-            self.add_prop(self.new_vocab_term(expr))
+        if self._is_new_vocab_expression(expr):
+            self.add_prop(self._vocab_term(expr))
+            return 'exec'
+
+        if self._is_del_vocab_expression(expr):
+            self.del_prop(self._vocab_term(expr))
             return 'exec'
 
         for p, obj in self.props.items():
@@ -90,11 +100,15 @@ class ModelSpace:
         return result
 
     @staticmethod
-    def is_new_vocab_expression(expression):
+    def _is_new_vocab_expression(expression):
         return expression.lower().startswith('new ') and len(expression.split()) == 2
 
     @staticmethod
-    def new_vocab_term(expression):
+    def _is_del_vocab_expression(expression):
+        return expression.lower().startswith('del ') and len(expression.split()) == 2
+
+    @staticmethod
+    def _vocab_term(expression):
         return expression.split()[-1]
 
     def get_status_text(self):

--- a/utest/test_modelspace.py
+++ b/utest/test_modelspace.py
@@ -44,6 +44,12 @@ class TestModelSpace(unittest.TestCase):
         self.m.add_prop('foo')
         self.assertIn('foo', dir(self.m))
 
+    def test_delete_property(self):
+        self.m.add_prop('foo')
+        self.assertIn('foo', dir(self.m))
+        self.m.del_prop('foo')
+        self.assertNotIn('foo', dir(self.m))
+
     def test_try_add_same_property(self):
         self.m.add_prop('foo')
         self.assertRaises(ModellingError, self.m.add_prop, 'foo')
@@ -159,6 +165,15 @@ class TestModelSpace(unittest.TestCase):
 
     def test_fail_exists_check_before_using_new_with_stripping(self):
         self.assertRaises(NameError, self.m.process_expression, ' foo ')
+
+    def test_fail_exists_check_after_using_del(self):
+        self.m.process_expression('new foo')
+        self.assertIn('foo', dir(self.m))
+        self.m.process_expression('del foo')
+        self.assertRaises(NameError, self.m.process_expression, 'foo')
+
+    def test_del_fails_if_property_does_not_exist(self):
+        self.assertRaises(ModellingError, self.m.process_expression, 'del foo')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Use passenger numbers from source
- Decouple total passenger number check
- Allow model cleanup by deleting vocab terms that go out of scope
- Make acceptance tests fail when removing given/then IN/OUT restriction

Regarding the last bullet, the asymmetry of processing IN-only for _givens_ and OUT-only for _thens_ is needed to specify the _then_-result independent of the actions. Especially useful when a composite action yields a new property. In the old situation removing this constraint would not cause the acceptance tests to fail.