### PR TITLE
Improved application of modelling guide in acceptance tests

### DIFF
--- a/atest/robotMBT tests/scenario_linking/01__then_to_given_linking.robot
+++ b/atest/robotMBT tests/scenario_linking/01__then_to_given_linking.robot
@@ -10,10 +10,10 @@ Library           robotmbt
 
 *** Test Cases ***
 leading scenario
-    When Johan buys a birthday card
-    then there is a blank birthday card
+    When someone buys a birthday card
+    then there is a blank birthday card available
 
 trailing scenario
-    Given there is a blank Birthday card
+    Given there is a blank birthday card available
     when 'Johan' writes their name on the birthday card
     then the birthday card has 'Johan' written on it

--- a/atest/robotMBT tests/scenario_linking/01__then_to_given_linking.robot
+++ b/atest/robotMBT tests/scenario_linking/01__then_to_given_linking.robot
@@ -10,7 +10,7 @@ Library           robotmbt
 
 *** Test Cases ***
 leading scenario
-    When buying a birthday card
+    When Johan buys a birthday card
     then there is a blank birthday card
 
 trailing scenario

--- a/atest/robotMBT tests/scenario_linking/01__then_to_given_linking.robot
+++ b/atest/robotMBT tests/scenario_linking/01__then_to_given_linking.robot
@@ -10,12 +10,10 @@ Library           robotmbt
 
 *** Test Cases ***
 leading scenario
-    Given a blank birthday card
-    when 'Johan' writes their name on the birthday card
-    then the birthday card has 'Johan' written on it
+    When buying a birthday card
+    then there is a blank birthday card
 
 trailing scenario
-    Given the birthday card has 'Johan' written on it
-    when 'Tannaz' writes their name on the birthday card
+    Given there is a blank Birthday card
+    when 'Johan' writes their name on the birthday card
     then the birthday card has 'Johan' written on it
-    and the birthday card has 'Tannaz' written on it

--- a/atest/robotMBT tests/scenario_linking/02__swapped_then_to_given_linking.robot
+++ b/atest/robotMBT tests/scenario_linking/02__swapped_then_to_given_linking.robot
@@ -16,5 +16,5 @@ trailing scenario
     then the birthday card has 'Johan' written on it
 
 leading scenario
-    When buying a birthday card
+    When Johan buys a birthday card
     then there is a blank birthday card

--- a/atest/robotMBT tests/scenario_linking/02__swapped_then_to_given_linking.robot
+++ b/atest/robotMBT tests/scenario_linking/02__swapped_then_to_given_linking.robot
@@ -11,10 +11,10 @@ Library           robotmbt
 
 *** Test Cases ***
 trailing scenario
-    Given there is a blank Birthday card
+    Given there is a blank birthday card available
     when 'Johan' writes their name on the birthday card
     then the birthday card has 'Johan' written on it
 
 leading scenario
-    When Johan buys a birthday card
-    then there is a blank birthday card
+    When someone buys a birthday card
+    then there is a blank birthday card available

--- a/atest/robotMBT tests/scenario_linking/02__swapped_then_to_given_linking.robot
+++ b/atest/robotMBT tests/scenario_linking/02__swapped_then_to_given_linking.robot
@@ -11,12 +11,10 @@ Library           robotmbt
 
 *** Test Cases ***
 trailing scenario
-    Given the birthday card has 'Johan' written on it
-    when 'Tannaz' writes their name on the birthday card
-    then the birthday card has 'Johan' written on it
-    and the birthday card has 'Tannaz' written on it
-
-leading scenario
-    Given a blank birthday card
+    Given there is a blank Birthday card
     when 'Johan' writes their name on the birthday card
     then the birthday card has 'Johan' written on it
+
+leading scenario
+    When buying a birthday card
+    then there is a blank birthday card

--- a/atest/robotMBT tests/scenario_linking/03__double_dependency.robot
+++ b/atest/robotMBT tests/scenario_linking/03__double_dependency.robot
@@ -6,29 +6,27 @@ Documentation     There are three test cases, one must go first. The other two a
 ...               force the model to reorganise the scenarios.
 Suite Setup       Suite setup
 Suite Teardown    Should be equal    ${test_count}    ${3}
-Test Setup        Test setup
+Task Setup        Test setup
 Resource          birthday_cards_flat.resource
 Library           robotmbt
 
 *** Test Cases ***
 trailing scenario
-    Given the birthday card has 'Johan' written on it
+    Given there is a Birthday card
     when 'Tannaz' writes their name on the birthday card
-    then the birthday card has 'Johan' written on it
-    and the birthday card has 'Tannaz' written on it
+    then the birthday card has 'Tannaz' written on it
     [Teardown]    Check order    ${3}
 
 middle scenario
-    Given the birthday card has 1 name written on it
-    when 'Nicolas' writes their name on the birthday card
-    then the birthday card has 'Nicolas' written on it
-    and the birthday card has 2 names written on it
+    Given there is a blank Birthday card
+    when 'Johan' writes their name on the birthday card
+    then the birthday card has 'Johan' written on it
+    and the birthday card has 1 name written on it
     [Teardown]    Check order    ${2}
 
 leading scenario
-    Given a blank birthday card
-    when 'Johan' writes their name on the birthday card
-    then the birthday card has 'Johan' written on it
+    When buying a birthday card
+    then there is a blank birthday card
     [Teardown]    Check order    ${1}
 
 *** Keywords ***

--- a/atest/robotMBT tests/scenario_linking/03__double_dependency.robot
+++ b/atest/robotMBT tests/scenario_linking/03__double_dependency.robot
@@ -12,21 +12,21 @@ Library           robotmbt
 
 *** Test Cases ***
 trailing scenario
-    Given there is a Birthday card
+    Given there is a birthday card
     when 'Tannaz' writes their name on the birthday card
     then the birthday card has 'Tannaz' written on it
     [Teardown]    Check order    ${3}
 
 middle scenario
-    Given there is a blank Birthday card
+    Given there is a blank birthday card available
     when 'Johan' writes their name on the birthday card
     then the birthday card has 'Johan' written on it
     and the birthday card has 1 name written on it
     [Teardown]    Check order    ${2}
 
 leading scenario
-    When Johan buys a birthday card
-    then there is a blank birthday card
+    When someone buys a birthday card
+    then there is a blank birthday card available
     [Teardown]    Check order    ${1}
 
 *** Keywords ***

--- a/atest/robotMBT tests/scenario_linking/03__double_dependency.robot
+++ b/atest/robotMBT tests/scenario_linking/03__double_dependency.robot
@@ -6,7 +6,7 @@ Documentation     There are three test cases, one must go first. The other two a
 ...               force the model to reorganise the scenarios.
 Suite Setup       Suite setup
 Suite Teardown    Should be equal    ${test_count}    ${3}
-Task Setup        Test setup
+Test Setup        Test setup
 Resource          birthday_cards_flat.resource
 Library           robotmbt
 
@@ -25,7 +25,7 @@ middle scenario
     [Teardown]    Check order    ${2}
 
 leading scenario
-    When buying a birthday card
+    When Johan buys a birthday card
     then there is a blank birthday card
     [Teardown]    Check order    ${1}
 

--- a/atest/robotMBT tests/scenario_linking/04__single_when_to_given_step_refinement.robot
+++ b/atest/robotMBT tests/scenario_linking/04__single_when_to_given_step_refinement.robot
@@ -13,12 +13,15 @@ Library           robotmbt
 
 *** Test Cases ***
 high-level scenario
-    Given a blank birthday card
-    when 'Johan' is written on the birthday card
+    Given there is a blank Birthday card
+    when 'Johan' writes their name on the birthday card
     then the birthday card has 'Johan' written on it
 
 low-level scenario
     Given there is a birthday card
     when 'Johan' writes their name in pen on the birthday card
-    then the birthday card has 'Johan' written on it
-    and 'Johan' is written in ink on the birthday card
+    then 'Johan' is written in ink on the birthday card
+
+leading scenario
+    When buying a birthday card
+    then there is a blank birthday card

--- a/atest/robotMBT tests/scenario_linking/04__single_when_to_given_step_refinement.robot
+++ b/atest/robotMBT tests/scenario_linking/04__single_when_to_given_step_refinement.robot
@@ -13,7 +13,7 @@ Library           robotmbt
 
 *** Test Cases ***
 high-level scenario
-    Given there is a blank Birthday card
+    Given there is a blank birthday card available
     when 'Johan' writes their name on the birthday card
     then the birthday card has 'Johan' written on it
 
@@ -23,5 +23,5 @@ low-level scenario
     then 'Johan' is written in ink on the birthday card
 
 leading scenario
-    When Johan buys a birthday card
-    then there is a blank birthday card
+    When someone buys a birthday card
+    then there is a blank birthday card available

--- a/atest/robotMBT tests/scenario_linking/04__single_when_to_given_step_refinement.robot
+++ b/atest/robotMBT tests/scenario_linking/04__single_when_to_given_step_refinement.robot
@@ -23,5 +23,5 @@ low-level scenario
     then 'Johan' is written in ink on the birthday card
 
 leading scenario
-    When buying a birthday card
+    When Johan buys a birthday card
     then there is a blank birthday card

--- a/atest/robotMBT tests/scenario_linking/06__composed_scenario.robot
+++ b/atest/robotMBT tests/scenario_linking/06__composed_scenario.robot
@@ -22,7 +22,7 @@ Sending Bahar a birthday card
 
 Bahar receives the birthday card
     Given a birthday card for Bahar was put in the mail
-    when the birthcard is is delivered to Bahar's mailbox
+    when the postal service delivers the birthday card to Bahar's mailbox
     then 'Bahar' received the birthday card
 
 Johan prefers pen

--- a/atest/robotMBT tests/scenario_linking/06__composed_scenario.robot
+++ b/atest/robotMBT tests/scenario_linking/06__composed_scenario.robot
@@ -9,15 +9,15 @@ Library           robotmbt
 
 *** Test Cases ***
 Buying a card
-    When Johan buys a birthday card
-    then there is a blank birthday card
+    When 'Johan' buys a birthday card
+    then there is a blank birthday card available
 
 Sending Bahar a birthday card
-    Given there is a blank birthday card
-    when 'Johan' is written on the birthday card
+    Given there is a blank birthday card available
+    when 'Johan' writes their name on the birthday card
     and 'Johan' writes Bahar's address on the birthday card
-    and 'Tannaz' is written on the birthday card
-    and 'Nicolas' is written on the birthday card
+    and 'Tannaz' writes their name on the birthday card
+    and 'Frederique' writes their name on the birthday card
     then 'Johan' puts the birthday card in the mail
 
 Bahar receives the birthday card
@@ -38,14 +38,14 @@ Tannaz prefers traditional style
     then the birthday card has 'Tannaz' written on it
     and there is text added in calligraphy on the birthday card
 
-Nicolas prefers pencil
+Frederique prefers pencil
     Given there is a birthday card
-    when 'Nicolas' writes their name in pencil on the birthday card
-    then the birthday card has 'Nicolas' written on it
+    when 'Frederique' writes their name in pencil on the birthday card
+    then the birthday card has 'Frederique' written on it
     and there is text added in pencil on the birthday card
 
 The pencil needs sharpening
     Given a pencil is needed for writing
     but the pencil has a broken tip
-    when the tip of the pencil is sharpend
+    when someone sharpens the tip of the pencil
     then the pencil is ready for writing

--- a/atest/robotMBT tests/scenario_linking/06__composed_scenario.robot
+++ b/atest/robotMBT tests/scenario_linking/06__composed_scenario.robot
@@ -9,7 +9,7 @@ Library           robotmbt
 
 *** Test Cases ***
 Buying a card
-    When buying a birthday card
+    When Johan buys a birthday card
     then there is a blank birthday card
 
 Sending Bahar a birthday card

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_common.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_common.resource
@@ -1,11 +1,17 @@
 *** Keywords ***
-a blank Birthday card
+buying a birthday card
     [Documentation]    *model info*
-    ...    :IN: new birthday_card | birthday_card.names=[]
-    ...    :OUT: None
+    ...    :IN: None
+    ...    :OUT: new birthday_card
     Log    choosing a birthday card with baloons
     @{names}=    Create list
     Set suite variable    ${names}
+
+there is a blank Birthday card
+    [Documentation]    *model info*
+    ...    :IN: birthday_card.names==[]
+    ...    :OUT: birthday_card.names=[]
+    Length should be    ${names}    0
 
 there is a birthday card
     [Documentation]    *model info*

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_common.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_common.resource
@@ -1,5 +1,5 @@
 *** Keywords ***
-Johan buys a birthday card
+someone buys a birthday card
     [Documentation]    *model info*
     ...    :IN: None
     ...    :OUT: new birthday_card
@@ -7,7 +7,7 @@ Johan buys a birthday card
     @{names}=    Create list
     Set suite variable    ${names}
 
-there is a blank Birthday card
+there is a blank birthday card available
     [Documentation]    *model info*
     ...    :IN: birthday_card.names==[]
     ...    :OUT: birthday_card.names=[]

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_common.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_common.resource
@@ -1,5 +1,5 @@
 *** Keywords ***
-buying a birthday card
+Johan buys a birthday card
     [Documentation]    *model info*
     ...    :IN: None
     ...    :OUT: new birthday_card

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
@@ -2,7 +2,7 @@
 Library    String
 
 *** Keywords ***
-buying a birthday card
+Johan buys a birthday card
     [Documentation]    *model info*
     ...    :IN: None
     ...    :OUT: new birthday_card

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
@@ -121,7 +121,7 @@ a birthday card for ${recepient} was put in the mail
     ...    :OUT: birthday_card.is_mailed | birthday_card.recepient == ${recepient}
     Log    a birthday card for ${recepient} was put in the mail
 
-the birthcard is is delivered to ${recepient}'s mailbox
+the postal service delivers the birthday card to ${recepient}'s mailbox
     [Documentation]    *model info*
     ...    :IN: birthday_card.is_mailed
     ...    :OUT: birthday_card.is_delivered = True | birthday_card.mailbox = ${recepient}

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_composed.resource
@@ -2,7 +2,7 @@
 Library    String
 
 *** Keywords ***
-Johan buys a birthday card
+'${person}' buys a birthday card
     [Documentation]    *model info*
     ...    :IN: None
     ...    :OUT: new birthday_card
@@ -10,7 +10,7 @@ Johan buys a birthday card
     @{names}=    Create list
     Set suite variable    ${names}
 
-there is a blank Birthday card
+there is a blank birthday card available
     [Documentation]    *model info*
     ...    :IN: birthday_card.names==[]
     ...    :OUT: birthday_card.names=[]
@@ -28,11 +28,11 @@ the birthday card has '${name}' written on it
     ...    :OUT: ${name} in birthday_card.names
     Should Contain    ${names}    ${name}
 
-'${name}' is written on the birthday card
+'${person}' writes their name on the birthday card
     [Documentation]    *model info*
     ...    :IN: birthday_card
-    ...    :OUT: ${name} in birthday_card.names
-    Should Contain    ${names}    ${name}
+    ...    :OUT: ${person} in birthday_card.names
+    Should Contain    ${names}    ${person}
 
 there is text added in ${style} on the birthday card
     [Documentation]    *model info*
@@ -40,43 +40,43 @@ there is text added in ${style} on the birthday card
     ...    :OUT: birthday_card.style == ${style}
     Should be equal    ${writing style}    ${style}
 
-'${name}' writes their name in pen on the birthday card
+'${person}' writes their name in pen on the birthday card
     [Documentation]    *model info*
     ...    :IN: birthday_card
-    ...    :OUT: birthday_card.names.append(${name}) | birthday_card.style = ink
-    Log    Writing '${name}' on the birthday card
-    Set suite variable    @{names}    @{names}    ${name}
-    Log    ${name} prefers to use a pen for writing
+    ...    :OUT: birthday_card.names.append(${person}) | birthday_card.style = ink
+    Log    Writing '${person}' on the birthday card
+    Set suite variable    @{names}    @{names}    ${person}
+    Log    ${person} prefers to use a pen for writing
     Set suite variable    ${writing style}    ink
 
-'${name}' writes their first letter as a piece of art
+'${person}' writes their first letter as a piece of art
     [Documentation]    *model info*
     ...    :IN: None
-    ...    :OUT: new artwork | artwork.name=${name}[0]
+    ...    :OUT: new artwork | artwork.name=${person}[0]
     ...          birthday_card.style = calligraphy
-    ${first_letter}=    Get substring    ${name}    0    0
-    Log    ${name} writes a beautiful capital letter ${first_letter}
+    ${first_letter}=    Get substring    ${person}    0    0
+    Log    ${person} writes a beautiful capital letter ${first_letter}
 
-'${name}' writes the other letters in decorative writing
+'${person}' writes the other letters in decorative writing
     [Documentation]    *model info*
     ...    :IN: artwork.name
-    ...    :OUT: artwork.name+=${name}[1:] | birthday_card.names.append(artwork.name)
+    ...    :OUT: artwork.name+=${person}[1:] | birthday_card.names.append(artwork.name)
     ...          birthday_card.style = calligraphy
     ...          del artwork
-    ${other_letters}=    Get substring    ${name}    1
-    Log    ${name} writes ${other_letters} in a matching font
-    Set suite variable    @{names}    @{names}    ${name}
-    Log    ${name} prefers to use a pen for writing
+    ${other_letters}=    Get substring    ${person}    1
+    Log    ${person} writes ${other_letters} in a matching font
+    Set suite variable    @{names}    @{names}    ${person}
+    Log    ${person} prefers to use a pen for writing
     Set suite variable    ${writing style}    calligraphy
 
-'${name}' writes their name in pencil on the birthday card
+'${person}' writes their name in pencil on the birthday card
     [Documentation]    *model info*
-    ...    :IN: birthday_card | new _pencil
-    ...    :OUT: _pencil.tip==sharp | birthday_card.names.append(${name})
+    ...    :IN: birthday_card | new _pencil | _pencil.tip=broken
+    ...    :OUT: _pencil.tip==sharp | birthday_card.names.append(${person})
     ...          birthday_card.style = pencil
     ...          del _pencil
-    Set suite variable    @{names}    @{names}    ${name}
-    Log    ${name} prefers to use a pencil for writing
+    Set suite variable    @{names}    @{names}    ${person}
+    Log    ${person} prefers to use a pencil for writing
     Set suite variable    ${writing style}    pencil
 
 a pencil is needed for writing
@@ -87,11 +87,11 @@ a pencil is needed for writing
 
 the pencil has a broken tip
     [Documentation]    *model info*
-    ...    :IN:  _pencil.tip=broken
+    ...    :IN:  _pencil.tip==broken
     ...    :OUT: _pencil.tip=broken
     Log    Oh no, I can't write like this :-(
 
-the tip of the pencil is sharpend
+someone sharpens the tip of the pencil
     [Documentation]    *model info*
     ...    :IN: _pencil.tip==broken
     ...    :OUT: _pencil.tip=sharp
@@ -103,13 +103,13 @@ the pencil is ready for writing
     ...    :OUT: _pencil.tip==sharp
     Log    I can work with this
 
-'${writer}' writes ${recepient}'s address on the birthday card
+'${sender}' writes ${recepient}'s address on the birthday card
     [Documentation]    *model info*
     ...    :IN: birthday_card
     ...    :OUT: birthday_card.recepient = ${recepient}
     Log    Writing ${recepient}'s name and address on the card
 
-'${name}' puts the birthday card in the mail
+'${person}' puts the birthday card in the mail
     [Documentation]    *model info*
     ...    :IN: birthday_card
     ...    :OUT: birthday_card.is_mailed = True
@@ -127,8 +127,8 @@ the birthcard is is delivered to ${recepient}'s mailbox
     ...    :OUT: birthday_card.is_delivered = True | birthday_card.mailbox = ${recepient}
     Log    Something fell on the doormat
 
-'${name}' received the birthday card
+'${person}' received the birthday card
     [Documentation]    *model info*
-    ...    :IN: birthday_card.is_delivered == True | birthday_card.mailbox == ${name}
-    ...    :OUT: birthday_card.is_delivered == True | birthday_card.mailbox == ${name}
-    Log    Something fell on ${name}'s doormat
+    ...    :IN: birthday_card.is_delivered == True | birthday_card.mailbox == ${person}
+    ...    :OUT: birthday_card.is_delivered == True | birthday_card.mailbox == ${person}
+    Log    Something fell on ${person}'s doormat

--- a/atest/robotMBT tests/scenario_linking/birthday_cards_layered.resource
+++ b/atest/robotMBT tests/scenario_linking/birthday_cards_layered.resource
@@ -2,7 +2,7 @@
 Resource          birthday_cards_common.resource
 
 *** Keywords ***
-'${name}' is written on the birthday card
+'${name}' writes their name on the birthday card
     [Documentation]    *model info*
     ...    :IN: birthday_card
     ...    :OUT: ${name} in birthday_card.names
@@ -19,6 +19,6 @@ Resource          birthday_cards_common.resource
 
 '${name}' is written in ink on the birthday card
     [Documentation]    *model info*
-    ...    :IN: birthday_card.style == pen
-    ...    :OUT: birthday_card.style == pen
+    ...    :IN: birthday_card.style == pen | ${name} in birthday_card.names
+    ...    :OUT: birthday_card.style == pen | ${name} in birthday_card.names
     Should be equal    ${writing style}    ink


### PR DESCRIPTION
The scenario linking test suite was constructed focusing on the different types of composition supported by the library. It did not yet follow the modelling guide that was also under development. This pull request irons out the anti-pattern of assigning model attributes from given-steps and now consistently uses third person actionable when-steps.