### PR TITLE
Reduce argument data restrictions

### DIFF
--- a/atest/resources/birthday_cards_flat.resource
+++ b/atest/resources/birthday_cards_flat.resource
@@ -2,7 +2,7 @@
 '${person}' buys a birthday card
     [Documentation]    *model info*
     ...    :IN: None
-    ...    :OUT: new birthday_card | birthday_card.with_whom = "${person}"
+    ...    :OUT: new birthday_card | birthday_card.with_whom = ${person}
     Log    choosing a birthday card with baloons
     Set suite variable    ${has_card}    ${person}
     @{names}=    Create list
@@ -22,28 +22,28 @@ there is a birthday card
 
 '${person}' has the birthday card
     [Documentation]    *model info*
-    ...    :IN: birthday_card.with_whom == "${person}"
-    ...    :OUT: birthday_card.with_whom == "${person}"
+    ...    :IN: birthday_card.with_whom == ${person}
+    ...    :OUT: birthday_card.with_whom == ${person}
     Log    The card is right here in ${person}'s hand
     Should be equal    ${has_card}    ${person}
 
 '${person}' writes their name on the birthday card
     [Documentation]    *model info*
     ...    :IN: birthday_card
-    ...    :OUT: birthday_card.names.append("${person}")
+    ...    :OUT: birthday_card.names.append(${person})
     Log    Writing '${person}' on the birthday card
     Set suite variable    @{names}    @{names}    ${person}
 
 the birthday card has '${name}' written on it
     [Documentation]    *model info*
-    ...    :IN: "${name}" in birthday_card.names
-    ...    :OUT: "${name}" in birthday_card.names
+    ...    :IN: ${name} in birthday_card.names
+    ...    :OUT: ${name} in birthday_card.names
     Should contain    ${names}    ${name}
 
 the birthday card does not have '${name}' written on it
     [Documentation]    *model info*
-    ...    :IN: "${name}" not in birthday_card.names
-    ...    :OUT: "${name}" not in birthday_card.names
+    ...    :IN: ${name} not in birthday_card.names
+    ...    :OUT: ${name} not in birthday_card.names
     Should not contain    ${names}    ${name}
 
 the birthday card has ${n} name${plural} written on it
@@ -54,8 +54,8 @@ the birthday card has ${n} name${plural} written on it
 
 '${person A}' passes the birthday card ${back/on} to '${person B}'
     [Documentation]    *model info*
-    ...    :IN: birthday_card.with_whom == "${person A}"
-    ...    :OUT: birthday_card.with_whom = "${person B}"
+    ...    :IN: birthday_card.with_whom == ${person A}
+    ...    :OUT: birthday_card.with_whom = ${person B}
     Log    Here you go ${person B}
     Log    Thank you ${person A}, I'll be sure to put name on here.
     Set suite variable    ${has_card}    ${person B}

--- a/atest/robotMBT tests/03__parse_model_info/incorrect_model_info.robot
+++ b/atest/robotMBT tests/03__parse_model_info/incorrect_model_info.robot
@@ -17,18 +17,18 @@ fail when colon syntax is used incorrectly
 empty model info
     [Documentation]    *model info*
     @{errors}=    Reported errors
-    Should be equal    ${errors[0].bare_kw}    empty model info
+    Should be equal    ${errors[0].kw_wo_gherkin}    empty model info
 
 non-colon model info
     [Documentation]    *model info*
     ...    *IN* Alfa
     ...    *OUT* Beta | Gamma delta | Epsilon
     @{errors}=    Reported errors
-    Should be equal    ${errors[1].bare_kw}    non-colon model info
+    Should be equal    ${errors[1].kw_wo_gherkin}    non-colon model info
 
 forgotten opening colon
     [Documentation]    *model info*
     ...    IN: Alfa
     ...    OUT: Beta | Gamma delta | Epsilon
     @{errors}=    Reported errors
-    Should be equal    ${errors[2].bare_kw}    forgotten opening colon
+    Should be equal    ${errors[2].kw_wo_gherkin}    forgotten opening colon

--- a/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
+++ b/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
@@ -24,6 +24,11 @@ Argument with spaces
     when 'Gert Jan' writes their name on the birthday card
     then the birthday card has 'Gert Jan' written on it
 
+Argument with apostrophe
+    Given there is a birthday card
+    when 'Jeanne d'Arc' writes their name on the birthday card
+    then the birthday card has 'Jeanne d'Arc' written on it
+
 Argument with Python operator
     Given there is a birthday card
     when 'Gert-Jan' writes their name on the birthday card

--- a/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
+++ b/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
@@ -23,3 +23,18 @@ Argument with spaces
     Given there is a birthday card
     when 'Gert Jan' writes their name on the birthday card
     then the birthday card has 'Gert Jan' written on it
+
+Argument with Python operator
+    Given there is a birthday card
+    when 'Gert-Jan' writes their name on the birthday card
+    then the birthday card has 'Gert-Jan' written on it
+
+Argument with Python builtin function
+    Given there is a birthday card
+    when 'max' writes their name on the birthday card
+    then the birthday card has 'max' written on it
+
+Argument with Python keyword
+    Given there is a birthday card
+    when 'elif' writes their name on the birthday card
+    then the birthday card has 'elif' written on it

--- a/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
+++ b/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
@@ -8,38 +8,43 @@ leading scenario
     When 'Johan' buys a birthday card
     then there is a blank birthday card available
 
-Simple argument
+simple argument
     Given there is a birthday card
-    when 'Johan' writes their name on the birthday card
-    then the birthday card has 'Johan' written on it
+    when 'Gertjan' writes their name on the birthday card
+    then the birthday card has 'Gertjan' written on it
 
-Argument data is case sensitive
+argument data is case sensitive
     Given there is a birthday card
-    when 'Johan' writes their name on the birthday card
-    then the birthday card has 'Johan' written on it
-    but the birthday card does not have 'JOHAN' written on it
+    when 'GertJan' writes their name on the birthday card
+    then the birthday card has 'GertJan' written on it
+    but the birthday card does not have 'GERTJAN' written on it
 
-Argument with spaces
+argument with spaces
     Given there is a birthday card
     when 'Gert Jan' writes their name on the birthday card
     then the birthday card has 'Gert Jan' written on it
 
-Argument with apostrophe
-    Given there is a birthday card
-    when 'Jeanne d'Arc' writes their name on the birthday card
-    then the birthday card has 'Jeanne d'Arc' written on it
-
-Argument with Python operator
+argument with Python operator
     Given there is a birthday card
     when 'Gert-Jan' writes their name on the birthday card
     then the birthday card has 'Gert-Jan' written on it
 
-Argument with Python builtin function
+argument with apostrophe
+    Given there is a birthday card
+    when 'Jeanne d'Arc' writes their name on the birthday card
+    then the birthday card has 'Jeanne d'Arc' written on it
+
+argument in unicode
+    Given there is a birthday card
+    when '藤原拓海' writes their name on the birthday card
+    then the birthday card has '藤原拓海' written on it
+
+argument with Python builtin function
     Given there is a birthday card
     when 'max' writes their name on the birthday card
     then the birthday card has 'max' written on it
 
-Argument with Python keyword
+argument with Python keyword
     Given there is a birthday card
     when 'elif' writes their name on the birthday card
     then the birthday card has 'elif' written on it

--- a/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
+++ b/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Suite Setup       Treat this test suite Model-based
+Resource          ../../resources/birthday_cards_flat.resource
+Library           robotmbt
+
+*** Test Cases ***
+leading scenario
+    When 'Johan' buys a birthday card
+    then there is a blank birthday card available
+
+Simple argument
+    Given there is a birthday card
+    when 'Johan' writes their name on the birthday card
+    then the birthday card has 'Johan' written on it
+
+Argument data is case sensitive
+    Given there is a birthday card
+    when 'Johan' writes their name on the birthday card
+    then the birthday card has 'Johan' written on it
+    but the birthday card does not have 'JOHAN' written on it
+
+Argument with spaces
+    Given there is a birthday card
+    when 'Gert Jan' writes their name on the birthday card
+    then the birthday card has 'Gert Jan' written on it

--- a/demo/Titanic/Titanic_scenarios/step_defs.resource
+++ b/demo/Titanic/Titanic_scenarios/step_defs.resource
@@ -14,15 +14,15 @@ Titanic is scheduled for the voyage to New York
 
 Titanic is docked in the port of ${port}
     [Documentation]    *model info*
-    ...    :IN: Titanic.port == '${port}'
-    ...    :OUT: Titanic.port == '${port}'
+    ...    :IN: Titanic.port == ${port}
+    ...    :OUT: Titanic.port == ${port}
     Check that    Map area where 'Titanic's position' is located    Equals    ${port}
     Check that    Titanic's speed    equals    0
 
 Titanic sails from ${port A} to ${port B}
     [Documentation]    *model info*
-    ...    :IN: Titanic.port == '${port A}'
-    ...    :OUT: Titanic.port == '${port B}'
+    ...    :IN: Titanic.port == ${port A}
+    ...    :OUT: Titanic.port == ${port B}
     Check that    Map area where 'Titanic's position' is located    Equals    ${port B}
 
 Titanic departs for the port of ${port}
@@ -36,7 +36,7 @@ Titanic departs for the port of ${port}
 Titanic arrives in the port of ${port}
     [Documentation]    *model info*
     ...    :IN: Titanic.port == None
-    ...    :OUT: Titanic.port = '${port}'
+    ...    :OUT: Titanic.port = ${port}
     Check that    Map area where 'Titanic's position' is located    Equals    ${port}
     Titanic stops
 
@@ -105,6 +105,6 @@ Titanic's voyage is complete
 
 the date is ${date}
     [Documentation]    *model info*
-    ...    :IN: Date.now == '${date}'
-    ...    :OUT: Date.now == '${date}'
+    ...    :IN: Date.now == ${date}
+    ...    :OUT: Date.now == ${date}
     Check that    Current date of Journey    equals    ${date}

--- a/robotmbt/suitedata.py
+++ b/robotmbt/suitedata.py
@@ -106,7 +106,8 @@ class Step:
         self.keyword = name      # first cell of the Robot line, including step_kw, excluding args
         self.parent = parent     # Parent scenario for easy searching and processing
         self._gherkin_kw = None  # 'given', 'when', 'then' or None for non-bdd keywords
-        self.args = ()           # Comes directly from Robot
+        self.args = ()           # positional arguments taken directly from Robot
+        self.emb_args = dict()   # embedded arguments in format self.emb_args["${arg}"] = value
         self.model_info = dict() # Modelling information is available as a dictionary.
                                  # The standard format is dict(IN=[], OUT=[]) and can
                                  # optionally contain an error field.
@@ -142,6 +143,6 @@ class Step:
         return first_word if first_word.lower() in ['given','when','then','and','but'] else None
 
     @property
-    def bare_kw(self):
+    def kw_wo_gherkin(self):
         """The keyword without its Gherkin keyword. I.e., as it is known in Robot framework."""
         return self.keyword.replace(self.step_kw, '', 1).strip() if self.step_kw else self.keyword

--- a/robotmbt/suiteprocessors.py
+++ b/robotmbt/suiteprocessors.py
@@ -252,13 +252,11 @@ class SuiteProcessors:
                         refine_here = True
                     if refine_here:
                         front, back = scenario.split_at_step(i)
-                        edge_step = Step('Log', scenario)
-                        edge_step.args = (f"Refinement follows for step: {step.keyword}",)
+                        edge_step = Step('Log', f"Refinement follows for step: {step.keyword}", parent=scenario)
                         edge_step.gherkin_kw = step.gherkin_kw
                         edge_step.model_info = dict(IN=step.model_info['IN'], OUT=[])
                         front.steps.append(edge_step)
-                        edge_step = Step('Log', scenario)
-                        edge_step.args = (f"Refinement completed for step: {step.keyword}",)
+                        edge_step = Step('Log', f"Refinement completed for step: {step.keyword}", parent=scenario)
                         edge_step.gherkin_kw = step.gherkin_kw
                         edge_step.model_info = dict(IN=[], OUT=step.model_info['OUT'])
                         back.steps[0] = copy.deepcopy(back.steps[0])

--- a/robotmbt/suitereplacer.py
+++ b/robotmbt/suitereplacer.py
@@ -159,7 +159,8 @@ class SuiteReplacer:
                         try:
                             float(value)
                         except:
-                            value = f"'{value}'"
+                            escaped_value = value.replace("'", r"\'")
+                            value = f"'{escaped_value}'"
                 result[-1] = result[-1].replace(arg, value)
         return result
 

--- a/utest/test_suitedata.py
+++ b/utest/test_suitedata.py
@@ -332,12 +332,12 @@ class TestSteps(unittest.TestCase):
         for s, e in zip(self.steps, expected):
             self.assertEqual(s.step_kw, e)
 
-    def test_bare_keywords_are_stripped_from_their_gherkin_keyword(self):
+    def test_keywords_are_available_without_their_gherkin_keyword(self):
         expected = ['action keyword', 'step Gg1', 'step Ga1', 'step Gb1',
                                       'step Ww1', 'step Wa1', 'step Wb1',
                                       'step Tt1', 'step Ta1', 'step Tb1']
         for s, e in zip(self.steps, expected):
-            self.assertEqual(s.bare_kw, e)
+            self.assertEqual(s.kw_wo_gherkin, e)
 
     def test_arguments_can_be_stored(self):
         self.assertEqual(self.steps[0].args, ())

--- a/utest/test_suitedata.py
+++ b/utest/test_suitedata.py
@@ -31,6 +31,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+from unittest import mock
+
 from robotmbt.suitedata import Suite, Scenario, Step
 
 class TestSuites(unittest.TestCase):
@@ -61,7 +63,7 @@ class TestSuites(unittest.TestCase):
                          'topsuite.suite B.scenario BB')
 
     def test_error_in_suite_setup_is_detected(self):
-        step = Step('top setup', self.topsuite)
+        step = Step('top setup', parent=self.topsuite)
         step.gherkin_kw = 'given'
         step.model_info = dict(error='oops')
         self.topsuite.setup = step
@@ -78,7 +80,7 @@ class TestSuites(unittest.TestCase):
         self.assertEqual(errorsteps[0].model_info['error'], 'oops')
 
     def test_error_in_suite_teardown_is_detected(self):
-        step = Step('top teardown', self.topsuite)
+        step = Step('top teardown', parent=self.topsuite)
         step.model_info = dict(error='oops')
         self.topsuite.teardown = step
         self.assertIs(self.topsuite.has_error(), True)
@@ -88,7 +90,7 @@ class TestSuites(unittest.TestCase):
 
     def test_error_in_subsuite_setup_is_detected(self):
         suite = self.topsuite.suites[0]
-        step = Step('sub suite setup', suite)
+        step = Step('sub suite setup', parent=suite)
         step.gherkin_kw = 'given'
         step.model_info = dict(error='oops')
         suite.setup = step
@@ -106,7 +108,7 @@ class TestSuites(unittest.TestCase):
 
     def test_error_in_subsuite_teardown_is_detected(self):
         suite = self.topsuite.suites[0]
-        step = Step('sub suite teardown', suite)
+        step = Step('sub suite teardown', parent=suite)
         step.model_info = dict(error='oops')
         suite.teardown = step
         self.assertIs(self.topsuite.has_error(), True)
@@ -116,7 +118,7 @@ class TestSuites(unittest.TestCase):
 
     def test_error_in_subscenario_setup_is_detected(self):
         scenario = self.topsuite.suites[0].scenarios[0]
-        step = Step("sub suite's scenario teardown", scenario)
+        step = Step("sub suite's scenario teardown", parent=scenario)
         step.model_info = dict(error='oops')
         scenario.setup = step
         self.assertIs(self.topsuite.has_error(), True)
@@ -126,7 +128,7 @@ class TestSuites(unittest.TestCase):
 
     def test_error_in_subscenario_teardown_is_detected(self):
         scenario = self.topsuite.suites[0].scenarios[1]
-        step = Step("sub suite's scenario teardown", scenario)
+        step = Step("sub suite's scenario teardown", parent=scenario)
         step.model_info = dict(error='oops')
         scenario.teardown = step
         self.assertIs(self.topsuite.has_error(), True)
@@ -135,7 +137,7 @@ class TestSuites(unittest.TestCase):
         self.assertEqual(errorsteps[0].model_info['error'], 'oops')
 
     def test_multiple_errors_are_listed(self):
-        step = Step('top setup', self.topsuite)
+        step = Step('top setup', parent=self.topsuite)
         step.gherkin_kw = 'given'
         step.model_info = dict(error='setup oops')
         self.topsuite.setup = step
@@ -143,7 +145,7 @@ class TestSuites(unittest.TestCase):
             dict(error='scenario oops')
         self.topsuite.suites[0].scenarios[0].steps[1].model_info =\
             dict(error='sub scenario oops')
-        step = Step('sub teardown', self.topsuite)
+        step = Step('sub teardown', parent=self.topsuite)
         step.model_info = dict(error='sub teardown oops')
         self.topsuite.suites[0].scenarios[0].setup = step
 
@@ -193,24 +195,24 @@ class TestScenarios(unittest.TestCase):
         self.assertIs(self.scenario.teardown, None)
 
     def test_setup_errors(self):
-        step = Step('my setup', self.scenario)
+        step = Step('my setup', parent=self.scenario)
         step.model_info = dict(error='oops')
         self.scenario.setup = step
         self.assertIs(self.scenario.has_error(), True)
         self.assertEqual(self.scenario.steps_with_errors(), [self.scenario.setup])
 
     def test_teardown_errors(self):
-        step = Step('my teardown', self.scenario)
+        step = Step('my teardown', parent=self.scenario)
         step.model_info = dict(error='oops')
         self.scenario.teardown = step
         self.assertIs(self.scenario.has_error(), True)
         self.assertEqual(self.scenario.steps_with_errors(), [self.scenario.teardown])
 
     def test_combined_errors(self):
-        setup_step = Step('my setup', self.scenario)
+        setup_step = Step('my setup', parent=self.scenario)
         setup_step.model_info = dict(error='oops in setup')
         self.scenario.setup = setup_step
-        teardown_step = Step('my teardown', self.scenario)
+        teardown_step = Step('my teardown', parent=self.scenario)
         teardown_step.model_info = dict(error='oops in teardown')
         self.scenario.teardown = teardown_step
         self.scenario.steps[0].model_info = dict(error='oops in scenario 1')
@@ -279,20 +281,21 @@ class TestSteps(unittest.TestCase):
     def setUp(self):
         self.steps = self.create_steps()
 
+    @mock.patch.object(Step, '_Step__extract_data_from_robot')
     @staticmethod
-    def create_steps(parent=None):
-        Kw1 = Step('action keyword', parent)
-        Gg1 = Step('Given step Gg1', parent)
-        Ga1 = Step('and step Ga1', parent)
-        Gb1 = Step('but step Gb1', parent)
+    def create_steps(mock, parent=None):
+        Kw1 = Step('action keyword', parent=parent)
+        Gg1 = Step('Given step Gg1', parent=parent)
+        Ga1 = Step('and step Ga1', parent=parent)
+        Gb1 = Step('but step Gb1', parent=parent)
         Gg1.gherkin_kw= Ga1.gherkin_kw= Gb1.gherkin_kw= 'given'
-        Ww1 = Step('When step Ww1', parent)
-        Wa1 = Step('and step Wa1', parent)
-        Wb1 = Step('BUT step Wb1', parent)
+        Ww1 = Step('When step Ww1', parent=parent)
+        Wa1 = Step('and step Wa1', parent=parent)
+        Wb1 = Step('BUT step Wb1', parent=parent)
         Ww1.gherkin_kw= Wa1.gherkin_kw= Wb1.gherkin_kw= 'when'
-        Tt1 = Step('Then step Tt1', parent)
-        Ta1 = Step('And step Ta1', parent)
-        Tb1 = Step('but step Tb1', parent)
+        Tt1 = Step('Then step Tt1', parent=parent)
+        Ta1 = Step('And step Ta1', parent=parent)
+        Tb1 = Step('but step Tb1', parent=parent)
         Tt1.gherkin_kw= Ta1.gherkin_kw= Tb1.gherkin_kw= 'then'
         return [Kw1, Gg1, Ga1, Gb1, Ww1, Wa1, Wb1, Tt1, Ta1, Tb1]
 


### PR DESCRIPTION
Data from scenarios can be passed on for use in the model by using arguments in your keywords. Up to now, any argument value that did match Python's syntax for identifiers would cause the model to fail. This limitation has now been lifted.