### PR TITLE
Advanced modelling with step arguments

### DIFF
--- a/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
+++ b/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
@@ -60,6 +60,13 @@ argument with indisctinct name used in model
     Then domain term &#⚠️ is accessible from the model
     and property + is set to + for domain term &#⚠️
 
+argument values are kept as-is when used as value in the model
+    Given the birthday card has 'max' written on it
+    and the birthday card has 'Gert-Jan' written on it
+    and the birthday card has 'Jeanne d'Arc' written on it
+    and the birthday card has '藤原拓海' written on it
+    then the model includes these specific values
+
 *** Keywords ***
 a user introduces ${term} as new domain term to the model
     [Documentation]    *model info*
@@ -77,4 +84,16 @@ property ${property} is set to ${value} for domain term ${term}
     [Documentation]    *model info*
     ...    :IN: ${term}.${property} == ${value}
     ...    :OUT: ${term}.${property} = ${value}
+    No operation
+
+the model includes these specific values
+    [Documentation]    *model info*
+    ...    :IN: 'max' in birthday_card.names
+    ...         'Gert-Jan' in birthday_card.names
+    ...         '藤原拓海' in birthday_card.names
+    ...         "Jeanne d'Arc" in birthday_card.names
+    ...    :OUT: 'max' in birthday_card.names
+    ...         'Gert-Jan' in birthday_card.names
+    ...         '藤原拓海' in birthday_card.names
+    ...         "Jeanne d'Arc" in birthday_card.names
     No operation

--- a/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
+++ b/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
@@ -54,6 +54,12 @@ argument used as name in model
     Then domain term Birthday card is accessible from the model
     and property illustration design is set to birthday cake for domain term Birthday card
 
+argument with indisctinct name used in model
+    Given property illustration design is set to birthday cake for domain term Birthday card
+    When a user introduces &#⚠️ as new domain term to the model
+    Then domain term &#⚠️ is accessible from the model
+    and property + is set to + for domain term &#⚠️
+
 *** Keywords ***
 a user introduces ${term} as new domain term to the model
     [Documentation]    *model info*

--- a/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
+++ b/atest/robotMBT tests/03__parse_model_info/static_argument_data.robot
@@ -48,3 +48,27 @@ argument with Python keyword
     Given there is a birthday card
     when 'elif' writes their name on the birthday card
     then the birthday card has 'elif' written on it
+
+argument used as name in model
+    When a user introduces Birthday card as new domain term to the model
+    Then domain term Birthday card is accessible from the model
+    and property illustration design is set to birthday cake for domain term Birthday card
+
+*** Keywords ***
+a user introduces ${term} as new domain term to the model
+    [Documentation]    *model info*
+    ...    :IN: None
+    ...    :OUT: new ${term}
+    No operation
+
+domain term ${term} is accessible from the model
+    [Documentation]    *model info*
+    ...    :IN: ${term}.accessible == True
+    ...    :OUT: ${term}.accessible = True
+    No operation
+
+property ${property} is set to ${value} for domain term ${term}
+    [Documentation]    *model info*
+    ...    :IN: ${term}.${property} == ${value}
+    ...    :OUT: ${term}.${property} = ${value}
+    No operation

--- a/robotmbt/modelspace.py
+++ b/robotmbt/modelspace.py
@@ -83,9 +83,9 @@ class ModelSpace:
             return 'exec'
 
         for p in self.props:
-            exec(f"{p} = self.props['{p}']")
+            exec(f"{p} = self.props['{p}']", locals())
         for v in self.values:
-            exec(f"{v} = '{self.values[v]}'")
+            exec(f"{v} = '{self.values[v]}'", locals())
         try:
             result = eval(expr, locals())
         except SyntaxError:
@@ -106,7 +106,7 @@ class ModelSpace:
             raise ModellingError(f"{err.name} used before assignment")
 
         for p in self.props:
-            exec(f"self.props['{p}'] = {p}")
+            exec(f"self.props['{p}'] = {p}", locals())
 
         return result
 

--- a/robotmbt/modelspace.py
+++ b/robotmbt/modelspace.py
@@ -32,6 +32,8 @@
 
 import copy
 
+from .steparguments import StepArguments
+
 class ModellingError(Exception):
     pass
 
@@ -70,10 +72,8 @@ class ModelSpace:
         else:
             return self.__dict__.keys()
 
-    def process_expression(self, expression, emb_args={}):
-        expr = expression.strip()
-        for arg in emb_args:
-            expr = arg.substitute_in(expr, as_code=True)
+    def process_expression(self, expression, emb_args=StepArguments()):
+        expr = emb_args.fill_in_args(expression.strip(), as_code=True)
         if self._is_new_vocab_expression(expr):
             self.add_prop(self._vocab_term(expr))
             return 'exec'

--- a/robotmbt/steparguments.py
+++ b/robotmbt/steparguments.py
@@ -86,6 +86,8 @@ class StepArgument:
     @staticmethod
     def make_identifier(s):
         _s = str(s).replace(' ', '_')
-        if s.isidentifier():
-            return f"_{_s}" if iskeyword(_s) or _s in dir(builtins) else _s
-        return ''.join([c if c.isidentifier() else f"o{ord(c)}" for c in _s])
+        if _s.isidentifier():
+            return f"{_s}_" if iskeyword(_s) or _s in dir(builtins) else _s
+        if _s[:1].isdecimal():
+            _s = f'_{_s}'
+        return ''.join([c if c.isidentifier() or c.isdecimal() else f"o{ord(c)}" for c in _s])

--- a/robotmbt/steparguments.py
+++ b/robotmbt/steparguments.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2024, J. Foederer
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from keyword import iskeyword
+import builtins
+
+
+class StepArguments(list):
+    def __init__(self, iterable=[]):
+        super().__init__(item.copy() for item in iterable)
+
+    def fill_in_args(self, text, as_code=False):
+        result = text
+        for arg in self:
+            sub = arg.codestring if as_code else arg.value
+            result = result.replace(arg.arg, sub)
+        return result
+
+
+class StepArgument:
+    def __init__(self, arg_name, value):
+        self.arg = "${%s}" % arg_name
+        self.org_value = value
+        self._value = None
+        self._codestr = None
+        self.value = value
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
+        self._codestr = self.make_codestring(value)
+
+    @property
+    def codestring(self):
+        return self._codestr
+
+    def copy(self):
+        cp = StepArgument(self.arg.strip('${}'), self.value)
+        cp.org_value = self.org_value
+        return cp
+
+    @staticmethod
+    def make_codestring(text):
+        codestr = str(text)
+        if codestr.title() in ['None', 'True', 'False']:
+            return codestr.title()
+        try:
+            float(codestr)
+        except:
+            codestr = StepArgument.make_identifier(codestr)
+        return codestr
+
+    @staticmethod
+    def make_identifier(s):
+        _s = str(s).replace(' ', '_')
+        if s.isidentifier():
+            return f"_{_s}" if iskeyword(_s) or _s in dir(builtins) else _s
+        return ''.join([c if c.isidentifier() else f"o{ord(c)}" for c in _s])

--- a/robotmbt/suitedata.py
+++ b/robotmbt/suitedata.py
@@ -104,21 +104,21 @@ class Scenario:
 
 class Step:
     def __init__(self, steptext, *args, parent, prev_gherkin_kw=None):
-        self.keyword = steptext  # first cell of the Robot line, including step_kw, excluding args
-        self.parent = parent     # Parent scenario for easy searching and processing
-        self.args = args         # positional and named arguments taken directly from Robot
+        self.org_step = steptext  # first cell of the Robot line, including step_kw, excluding args
+        self.parent = parent      # Parent scenario for easy searching and processing
+        self.args = args          # positional and named arguments taken directly from Robot
         self.gherkin_kw = self.step_kw if str(self.step_kw).lower() in ['given', 'when', 'then', 'none'] else prev_gherkin_kw
-                                 # 'given', 'when', 'then' or None for non-bdd keywords
-        self.signature = None    # Robot keyword with its embedded arguments in ${...} notation
-        self.emb_args = dict()   # embedded arguments in format self.emb_args["${arg}"] = value
-        self.model_info = dict() # Modelling information is available as a dictionary.
-                                 # The standard format is dict(IN=[], OUT=[]) and can
-                                 # optionally contain an error field.
-                                 # IN and OUT are lists of Python evaluatable expressions.
-                                 # The `new vocab` form can be used to create new domain objects.
-                                 # The `vocab.attribute` form can then be used to express relations
-                                 # between properties from the domain vocabulaire.
-                                 # Custom processors can define their own attributes.
+                                  # 'given', 'when', 'then' or None for non-bdd keywords
+        self.signature = None     # Robot keyword with its embedded arguments in ${...} notation
+        self.emb_args = dict()    # embedded arguments in format self.emb_args["${arg}"] = value
+        self.model_info = dict()  # Modelling information is available as a dictionary.
+                                  # The standard format is dict(IN=[], OUT=[]) and can
+                                  # optionally contain an error field.
+                                  # IN and OUT are lists of Python evaluatable expressions.
+                                  # The `new vocab` form can be used to create new domain objects.
+                                  # The `vocab.attribute` form can then be used to express relations
+                                  # between properties from the domain vocabulaire.
+                                  # Custom processors can define their own attributes.
         self.__extract_data_from_robot()
 
     def __str__(self):
@@ -134,6 +134,15 @@ class Step:
         return self.model_info.get('error')
 
     @property
+    def keyword(self):
+        if not self.signature:
+            return self.org_step
+        s = f"{self.step_kw} {self.signature}" if self.step_kw else self.signature
+        for arg, value in self.emb_args.items():
+            s = s.replace(arg, value, 1)
+        return s
+
+    @property
     def gherkin_kw(self):
         return self._gherkin_kw
 
@@ -143,7 +152,7 @@ class Step:
 
     @property
     def step_kw(self):
-        first_word = self.keyword.split()[0]
+        first_word = self.org_step.split()[0]
         return first_word if first_word.lower() in ['given','when','then','and','but'] else None
 
     @property
@@ -153,13 +162,13 @@ class Step:
 
     def __extract_data_from_robot(self):
         try:
-            runner = BuiltIn()._namespace.get_runner(self.keyword)
+            runner = BuiltIn()._namespace.get_runner(self.org_step)
             if hasattr(runner, 'error'):
                 raise ValueError(runner.error)
             kw = runner.keyword
-            self.signature = kw.name
             self.emb_args = dict() if not kw.embedded else dict(zip(["${%s}" % a for a in kw.embedded.args],
                                                                     kw.embedded.match(self.kw_wo_gherkin).groups()))
+            self.signature = kw.name
             self.model_info = self.__parse_model_info(kw._doc)
         except Exception as ex:
             self.model_info['error']=str(ex)

--- a/robotmbt/suitedata.py
+++ b/robotmbt/suitedata.py
@@ -33,6 +33,9 @@
 import copy
 from robot.libraries.BuiltIn import BuiltIn
 
+from keyword import iskeyword
+import builtins
+
 class Suite:
     def __init__(self, name, parent=None):
         self.name = name
@@ -212,7 +215,13 @@ class Step:
                         try:
                             float(value)
                         except:
-                            escaped_value = value.replace("'", r"\'")
-                            value = f"'{escaped_value}'"
+                            value = self.make_identifier(value)
                 result[-1] = result[-1].replace(arg, value)
         return result
+
+    @staticmethod
+    def make_identifier(s):
+        _s = s.replace(' ', '_')
+        if s.isidentifier():
+            return f"_{_s}" if iskeyword(_s) or _s in dir(builtins) else _s
+        return ''.join([c if c.isidentifier() else f"o{ord(c)}" for c in _s])

--- a/robotmbt/suiteprocessors.py
+++ b/robotmbt/suiteprocessors.py
@@ -181,7 +181,7 @@ class SuiteProcessors:
                     try:
                         updated_model = self.tracestate.model
                         for expr in exit_conditions:
-                            if updated_model.process_expression(expr) is False:
+                            if updated_model.process_expression(expr, part2.steps[0].emb_args) is False:
                                  insert_valid_here = False
                                  break
                     except Exception:
@@ -213,7 +213,7 @@ class SuiteProcessors:
             if step.gherkin_kw in ['given', 'when']:
                 for expr in step.model_info['IN']:
                     try:
-                        if m.process_expression(expr) is False:
+                        if m.process_expression(expr, step.emb_args) is False:
                             return False
                     except Exception:
                         return False
@@ -221,7 +221,7 @@ class SuiteProcessors:
                 step_completes = False
                 for expr in step.model_info['OUT']:
                     try:
-                        if m.process_expression(expr) is False:
+                        if m.process_expression(expr, step.emb_args) is False:
                             break
                     except Exception:
                         break
@@ -241,12 +241,12 @@ class SuiteProcessors:
             step = scenario.steps[i]
             if step.gherkin_kw in ['given', 'when']:
                 for expr in step.model_info['IN']:
-                    m.process_expression(expr)
+                    m.process_expression(expr, step.emb_args)
             if step.gherkin_kw in ['when', 'then']:
                 for expr in step.model_info['OUT']:
                     refine_here = False
                     try:
-                        if m.process_expression(expr) is False:
+                        if m.process_expression(expr, step.emb_args) is False:
                              refine_here = True
                     except Exception:
                         refine_here = True
@@ -255,10 +255,12 @@ class SuiteProcessors:
                         edge_step = Step('Log', f"Refinement follows for step: {step.keyword}", parent=scenario)
                         edge_step.gherkin_kw = step.gherkin_kw
                         edge_step.model_info = dict(IN=step.model_info['IN'], OUT=[])
+                        edge_step.emb_args = step.emb_args[:]
                         front.steps.append(edge_step)
                         edge_step = Step('Log', f"Refinement completed for step: {step.keyword}", parent=scenario)
                         edge_step.gherkin_kw = step.gherkin_kw
                         edge_step.model_info = dict(IN=[], OUT=step.model_info['OUT'])
+                        edge_step.emb_args = step.emb_args[:]
                         back.steps[0] = copy.deepcopy(back.steps[0])
                         back.steps[0].model_info = dict(IN=[], OUT=[])
                         back.steps.insert(0, edge_step)
@@ -270,7 +272,7 @@ class SuiteProcessors:
         m = model.copy()
         for step in scenario.steps:
             for expr in SuiteProcessors._relevant_expressions(step):
-                m.process_expression(expr)
+                m.process_expression(expr, step.emb_args)
         return m
 
     @staticmethod
@@ -282,8 +284,8 @@ class SuiteProcessors:
                 return False
             for expr in SuiteProcessors._relevant_expressions(step):
                 try:
-                    if m.process_expression(expr) is False:
-                        logger.debug(f"Unable to insert scenario {scenario.name} due to step {step.keyword}: {expr} is False")
+                    if m.process_expression(expr, step.emb_args) is False:
+                        logger.debug(f"Unable to insert scenario {scenario.name} due to step {step.keyword}: {expr} is False") # report with filled in args
                         logger.debug(f"last state:\n{m.get_status_text()}")
                         return False
                 except Exception as err:

--- a/robotmbt/suiteprocessors.py
+++ b/robotmbt/suiteprocessors.py
@@ -39,6 +39,7 @@ from robot.api import logger
 
 from .suitedata import Suite, Scenario, Step
 from .tracestate import TraceState
+from .steparguments import StepArguments
 
 class SuiteProcessors:
     @not_keyword
@@ -255,12 +256,12 @@ class SuiteProcessors:
                         edge_step = Step('Log', f"Refinement follows for step: {step.keyword}", parent=scenario)
                         edge_step.gherkin_kw = step.gherkin_kw
                         edge_step.model_info = dict(IN=step.model_info['IN'], OUT=[])
-                        edge_step.emb_args = step.emb_args[:]
+                        edge_step.emb_args = StepArguments(step.emb_args)
                         front.steps.append(edge_step)
                         edge_step = Step('Log', f"Refinement completed for step: {step.keyword}", parent=scenario)
                         edge_step.gherkin_kw = step.gherkin_kw
                         edge_step.model_info = dict(IN=[], OUT=step.model_info['OUT'])
-                        edge_step.emb_args = step.emb_args[:]
+                        edge_step.emb_args = StepArguments(step.emb_args)
                         back.steps[0] = copy.deepcopy(back.steps[0])
                         back.steps[0].model_info = dict(IN=[], OUT=[])
                         back.steps.insert(0, edge_step)
@@ -285,7 +286,7 @@ class SuiteProcessors:
             for expr in SuiteProcessors._relevant_expressions(step):
                 try:
                     if m.process_expression(expr, step.emb_args) is False:
-                        logger.debug(f"Unable to insert scenario {scenario.name} due to step {step.keyword}: {expr} is False") # report with filled in args
+                        logger.debug(f"Unable to insert scenario {scenario.name} due to step {step.keyword}: {expr} is False")
                         logger.debug(f"last state:\n{m.get_status_text()}")
                         return False
                 except Exception as err:

--- a/utest/test_steparguments.py
+++ b/utest/test_steparguments.py
@@ -178,7 +178,11 @@ class TestStepArgument(unittest.TestCase):
     def test_keep_identifier_names_close_to_original(self):
         self.assertEqual(StepArgument.make_identifier('foo bar'), 'foo_bar')
         self.assertEqual(StepArgument.make_identifier('import'), 'import_')
-        self.assertTrue(StepArgument.make_identifier('4foo2bar').endwith('foo2bar'))
+        self.assertTrue(StepArgument.make_identifier('4foo2bar').endswith('foo2bar'))
+
+
+class TestStepArguments(unittest.TestCase):
+    pass
 
 
 if __name__ == '__main__':

--- a/utest/test_steparguments.py
+++ b/utest/test_steparguments.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2024, J. Foederer
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from robotmbt.steparguments import StepArgument, StepArguments
+
+
+class TestStepArgument(unittest.TestCase):
+    def test_arg_is_in_robot_notation(self):
+        arg1 = StepArgument('foo', 7)
+        arg2 = StepArgument('foo bar', 7)
+        arg3 = StepArgument('foo_bar', 7)
+        self.assertEqual(arg1.arg, '${foo}')
+        self.assertEqual(arg2.arg, '${foo bar}')
+        self.assertEqual(arg3.arg, '${foo_bar}')
+
+    def test_value_is_kept_as_is_number(self):
+        arg1 = StepArgument('foo', 7)
+        arg2 = StepArgument('foo', 2.7)
+        arg3 = StepArgument('foo', -8)
+        self.assertEqual(arg1.value, 7)
+        self.assertEqual(arg2.value, 2.7)
+        self.assertEqual(arg3.value, -8)
+
+    def test_value_is_kept_as_is_str(self):
+        arg1 = StepArgument('foo', 'bar')
+        arg2 = StepArgument('foo', 'bar bar ')
+        arg3 = StepArgument('foo', '${bar}')
+        arg4 = StepArgument('foo', '\t')
+        self.assertEqual(arg1.value, 'bar')
+        self.assertEqual(arg2.value, 'bar bar ')
+        self.assertEqual(arg3.value, '${bar}')
+        self.assertEqual(arg4.value, '\t')
+
+    def test_value_is_kept_as_is_immutable(self):
+        arg1 = StepArgument('foo', None)
+        arg2 = StepArgument('foo', True)
+        arg3 = StepArgument('foo', False)
+        self.assertEqual(arg1.value, None)
+        self.assertEqual(arg2.value, True)
+        self.assertEqual(arg3.value, False)
+
+    def test_original_value_is_kept_when_changing_value(self):
+        """helps to restore the original step text"""
+        arg1 = StepArgument('foo', 7)
+        self.assertEqual(arg1.value, 7)
+        arg1.value = 8
+        self.assertEqual(arg1.org_value, 7)
+        self.assertEqual(arg1.value, 8)
+
+    def test_copies_are_the_same(self):
+        arg1 = StepArgument('foo', 7)
+        arg2 = arg1.copy()
+        self.assertEqual(arg1.arg, arg2.arg)
+        self.assertEqual(arg1.value, arg2.value)
+        self.assertEqual(arg1.org_value, arg2.org_value)
+        self.assertEqual(arg1.codestring, arg2.codestring)
+
+    def test_original_value_is_kept_when_copying(self):
+        arg1 = StepArgument('foo', 7)
+        arg1.value = 8
+        arg2 = arg1.copy()
+        self.assertEqual(arg2.org_value, 7)
+        self.assertEqual(arg2.value, 8)
+
+    def test_copies_are_independent(self):
+        arg1 = StepArgument('foo', 7)
+        arg1.value = 8
+        arg2 = arg1.copy()
+        arg2.value = 13
+        self.assertEqual(arg2.value, 13)
+        self.assertEqual(arg1.value, 8)
+        self.assertEqual(arg1.org_value, arg2.org_value)
+
+    def test_bool_and_none_values_are_kept_for_code(self):
+        arg1 = StepArgument('foo', None)
+        arg2 = StepArgument('foo', True)
+        arg3 = StepArgument('foo', False)
+        self.assertEqual(arg1.codestring, 'None')
+        self.assertEqual(arg2.codestring, 'True')
+        self.assertEqual(arg3.codestring, 'False')
+
+    def test_number_values_stay_numbers_for_code(self):
+        arg1 = StepArgument('foo', 1)
+        arg2 = StepArgument('foo', 0)
+        arg3 = StepArgument('foo', -1)
+        arg4 = StepArgument('foo', 2.7)
+        arg5 = StepArgument('foo', 12E-1)
+        arg6 = StepArgument('foo', 0xa)
+        self.assertEqual(arg1.codestring, '1')
+        self.assertEqual(arg2.codestring, '0')
+        self.assertEqual(arg3.codestring, '-1')
+        self.assertEqual(arg4.codestring, '2.7')
+        self.assertEqual(arg5.codestring, '1.2')
+        self.assertEqual(arg6.codestring, '10')
+
+    def test_empty_string_stays_empty(self):
+        arg1 = StepArgument('foo', '')
+        self.assertEqual(arg1.codestring, '')
+
+    def test_spaces_and_underscores_are_interchangable(self):
+        arg1 = StepArgument('foo', 'foo bar')
+        arg2 = StepArgument('foo', 'foo_bar')
+        self.assertEqual(arg1.codestring, arg2.codestring)
+
+    def test_other_values_become_unique_identifiers(self):
+        valuelist = ['bar', 'foo bar', 'foo2bar', '${bar}',  # strings
+                     ' ', '\t', '\n', '  ', ' \n', '\a',     # whitespace/non-printable
+                     '#', '+-', '-+', '"', "'", 'パイ',      # special characters
+                     max, 'elif', 'import', 'new', 'del',    # reserved words
+                     lambda x: x/2, self, unittest.TestCase] # functions and objects
+        argsset = set()
+        for v in valuelist:
+            arg = StepArgument('foo', v)
+            self.assertTrue(arg.codestring.isidentifier())
+            argsset.add(arg.codestring)
+        self.assertEqual(len(valuelist), len(argsset))
+
+    def test_valid_identifiers_remain_unchanged(self):
+        arg1 = StepArgument('foo', 'bar')
+        arg2 = StepArgument('foo', 'bar1')
+        arg3 = StepArgument('foo', 'foo_bar')
+        arg4 = StepArgument('foo', '__bar')
+        arg5 = StepArgument('foo', 'class_')
+        arg6 = StepArgument('foo', 'パ')
+        self.assertEqual(arg1.codestring, 'bar')
+        self.assertEqual(arg2.codestring, 'bar1')
+        self.assertEqual(arg3.codestring, 'foo_bar')
+        self.assertEqual(arg4.codestring, '__bar')
+        self.assertEqual(arg5.codestring, 'class_')
+        self.assertEqual(arg6.codestring, 'パ')
+
+    def test_identical_values_yield_same_codestring(self):
+        arg1 = StepArgument('foo', 'bar')
+        arg2 = StepArgument('foo', 'bar')
+        self.assertEqual(arg1.codestring, arg2.codestring)
+        arg3 = StepArgument('foo', '1A')
+        arg4 = StepArgument('foo', '1A')
+        self.assertEqual(arg3.codestring, arg4.codestring)
+        arg5 = StepArgument('foo', ' +')
+        arg6 = StepArgument('foo', ' +')
+        self.assertEqual(arg5.codestring, arg6.codestring)
+
+    def test_number_bool_none_identifiers(self):
+        for v in [1, 0, -1, None, True, False]:
+            self.assertTrue(StepArgument.make_identifier(v).isidentifier())
+
+    def test_keep_identifier_names_close_to_original(self):
+        self.assertEqual(StepArgument.make_identifier('foo bar'), 'foo_bar')
+        self.assertEqual(StepArgument.make_identifier('import'), 'import_')
+        self.assertTrue(StepArgument.make_identifier('4foo2bar').endwith('foo2bar'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This update allows arguments from Robot steps to be used more broadly. Previously you could already assign argument values to properties defined in your model, i.e. `myItem.myProperty = ${arg}`. Now you can also create domain terms and properties using the argument values. e.g. `new ${arg}` or `something.${arg} = myValue`.