### PR TITLE
Robot Framework 7.3 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 keywords = ["robotframework", "robot", "mbt", "bdd", "testing"]
 dependencies = [
-    "robotframework >= 7.1",
+    "robotframework >= 7.3",
 ]
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robotframework-mbt"
-version = "0.7.0"
+version = "0.8.0"
 description = "Model-Based Testing in Robot framework with test case generation"
 readme = "README.md"
 authors = [{ name = "Johan Foederer", email = "github@famfoe.nl" }]

--- a/robotmbt/suitedata.py
+++ b/robotmbt/suitedata.py
@@ -178,7 +178,7 @@ class Step:
                 raise ValueError(robot_kw.error)
             if robot_kw.embedded:
                 self.emb_args = StepArguments([StepArgument(*match) for match in
-                                 zip(robot_kw.embedded.args, robot_kw.embedded.match(self.kw_wo_gherkin).groups())])
+                                 zip(robot_kw.embedded.args, robot_kw.embedded.parse_args(self.kw_wo_gherkin))])
             self.signature = robot_kw.name
             self.model_info = self.__parse_model_info(robot_kw._doc)
         except Exception as ex:

--- a/robotmbt/version.py
+++ b/robotmbt/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.7.0'
+VERSION = '0.8.0'

--- a/utest/test_suitedata.py
+++ b/utest/test_suitedata.py
@@ -406,7 +406,7 @@ class RobotKwStub:
         self._doc = "*model info*\n:IN: None\n:OUT: None"
         self.error = False
         self.embedded = SimpleNamespace(args=['${foo}', '${bar}'],
-                                        match= lambda _: SimpleNamespace(groups=lambda: ['foo_value', 'bar_value']))
+                                        parse_args= lambda _: ['foo_value', 'bar_value'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Due to a change in how Robot Framework parses embedded arguments, running older RobotMBT versions on Robot Framework 7.3 will yield a deprecation warning: _'EmbeddedArguments.match()' is deprecated since Robot Framework 7.3_