### PR TITLE
Prevent absorbing keyword timeout

### DIFF
--- a/robotmbt/modeller.py
+++ b/robotmbt/modeller.py
@@ -34,7 +34,7 @@ from typing import Any
 
 from robot.api import logger
 from robot.utils import is_list_like
-from robot.errors import ExecutionFailed  # Raised by Robot in case of keyword timeout
+from robot.errors import TimeoutExceeded  # Raised by Robot in case of keyword timeout
 
 from .modelspace import ModelSpace
 from .steparguments import StepArgument, StepArguments, ArgKind
@@ -81,7 +81,7 @@ def process_scenario(scenario: Scenario, model: ModelSpace) -> tuple[Scenario, S
                     else:
                         return None, None, dict(fail_msg=f"Unable to insert scenario {scenario.src_id}, "
                                                 f"{scenario.name}, due to step '{step}': [{expr}] is False")
-            except ExecutionFailed:
+            except TimeoutExceeded:
                 raise
             except Exception as err:
                 return None, None, dict(fail_msg=f"Unable to insert scenario {scenario.src_id}, "
@@ -132,7 +132,7 @@ def handle_refinement_exit(inserted_refinement: Scenario, tracestate: TraceState
         try:
             if tracestate.model.process_expression(expr, refinement_tail.steps[1].args) is False:
                 break
-        except ExecutionFailed:
+        except TimeoutExceeded:
             raise
         except Exception:
             break
@@ -216,7 +216,7 @@ def generate_scenario_variant(scenario: Scenario, model: ModelSpace) -> Scenario
                         step.args[modded_arg].value = modded_free_args
                 else:
                     raise AssertionError(f"Unknown argument kind for {modded_arg}")
-    except ExecutionFailed:
+    except TimeoutExceeded:
         raise
     except Exception as err:
         logger.debug(f"Unable to insert scenario {scenario.src_id}, {scenario.name}, due to modifier\n"

--- a/robotmbt/steparguments.py
+++ b/robotmbt/steparguments.py
@@ -116,7 +116,7 @@ class StepArgument:
             return codestr.title()
         try:
             float(codestr)
-        except:
+        except (TypeError, ValueError, OverflowError, ZeroDivisionError):
             codestr = StepArgument.make_identifier(codestr)
         return codestr
 

--- a/robotmbt/substitutionmap.py
+++ b/robotmbt/substitutionmap.py
@@ -118,7 +118,7 @@ class Constraint:
             # Keep the items in optionset unique. Refrain from using Python sets
             # due to non-deterministic behaviour when using random seeding.
             self.optionset: list[Any] = list(dict.fromkeys(constraint))
-        except:
+        except TypeError:
             self.optionset = None
         if not self.optionset or isinstance(constraint, str):
             raise ValueError(f"Invalid option set for initial constraint: {constraint}")

--- a/robotmbt/suitedata.py
+++ b/robotmbt/suitedata.py
@@ -33,6 +33,7 @@
 import copy
 from typing import Literal
 
+from robot.errors import ExecutionFailed  # Raised by Robot in case of keyword timeout
 from robot.running.arguments.argumentspec import ArgumentSpec
 from robot.running.arguments.argumentvalidator import ArgumentValidator
 from robot.running.keywordimplementation import KeywordImplementation
@@ -232,6 +233,8 @@ class Step:
             self.args += self.__handle_non_embedded_arguments(robot_kw.args)
             self.signature = robot_kw.name
             self.model_info = self.__parse_model_info(robot_kw._doc)
+        except ExecutionFailed:
+            raise
         except Exception as ex:
             self.model_info['error'] = str(ex)
 

--- a/robotmbt/suitedata.py
+++ b/robotmbt/suitedata.py
@@ -33,7 +33,7 @@
 import copy
 from typing import Literal
 
-from robot.errors import ExecutionFailed  # Raised by Robot in case of keyword timeout
+from robot.errors import TimeoutExceeded  # Raised by Robot in case of keyword timeout
 from robot.running.arguments.argumentspec import ArgumentSpec
 from robot.running.arguments.argumentvalidator import ArgumentValidator
 from robot.running.keywordimplementation import KeywordImplementation
@@ -233,7 +233,7 @@ class Step:
             self.args += self.__handle_non_embedded_arguments(robot_kw.args)
             self.signature = robot_kw.name
             self.model_info = self.__parse_model_info(robot_kw._doc)
-        except ExecutionFailed:
+        except TimeoutExceeded:
             raise
         except Exception as ex:
             self.model_info['error'] = str(ex)


### PR DESCRIPTION
Keyword timeouts in Robot are triggered by raising a `TimeoutExceeded` exception. In Robot's exception classes tree this exception is derived from the regular `Exception` type, unlike similar exception types that interrupt _user_ code, like `KeyboardInterrupt` that are derived from `BaseException`. As a result, some broader exception traps could absorb a timeout exception, failing the keyword to be interrupted and getting stuck. This PR removes too generic catch-all clauses where possible and reraises `TimeoutExceeded` in situations where unknown exceptions can arise from code outside RobotMBT's control.